### PR TITLE
Add start location to options menu

### DIFF
--- a/data/scripts/field_moves.inc
+++ b/data/scripts/field_moves.inc
@@ -3,6 +3,8 @@ EventScript_CutTree:: @ 81BDF13
 	lockall
 	checkspeedchoice HM_BADGE_CHECKS, BADGE_PURGE
 	goto_if_eq EventScript_CutTree_SkipBadgeCheck
+	checkspeedchoice EARLY_CUT, EARLY_CUT_YES
+	goto_if_eq EventScript_CutTree_SkipBadgeCheck
 	goto_if_unset FLAG_BADGE02_GET, EventScript_CantCutTree
 EventScript_CutTree_SkipBadgeCheck::
 	checkpartymove MOVE_CUT

--- a/include/constants/speedchoice.h
+++ b/include/constants/speedchoice.h
@@ -35,8 +35,9 @@
 #define HM_BADGE_CHECKS     16
 #define EASY_SURGE_CANS     17
 #define NERF_BROCK          18
+#define START_LOCATION      19
 
-#define CURRENT_OPTIONS_NUM 19
+#define CURRENT_OPTIONS_NUM 20
 // ----------------------
 // STATIC OPTIONS
 // ----------------------
@@ -198,6 +199,16 @@
 #define NERF_YES 0
 #define NERF_NO  1
 #define NERF_OPTION_COUNT 2
+
+// --------------------
+// START LOCATION ENUM
+// --------------------
+#define START_LOCATION_NORMAL 0
+#define START_LOCATION_EEVEE 1
+#define START_LOCATION_LAPRAS 2
+#define START_LOCATION_SAFARI 3
+#define START_LOCATION_TOWER 4
+#define START_LOCATION_OPTION_COUNT 5
 
 // Enumeration for optionType in the Speedchoice struct below.
 

--- a/include/constants/speedchoice.h
+++ b/include/constants/speedchoice.h
@@ -36,8 +36,9 @@
 #define EASY_SURGE_CANS     17
 #define NERF_BROCK          18
 #define START_LOCATION      19
+#define EARLY_CUT           20
 
-#define CURRENT_OPTIONS_NUM 20
+#define CURRENT_OPTIONS_NUM 21
 // ----------------------
 // STATIC OPTIONS
 // ----------------------
@@ -209,6 +210,13 @@
 #define START_LOCATION_SAFARI 3
 #define START_LOCATION_TOWER 4
 #define START_LOCATION_OPTION_COUNT 5
+
+// --------------------
+// EARLY CUT ENUM
+// --------------------
+#define EARLY_CUT_YES 0
+#define EARLY_CUT_NO  1
+#define EARLY_CUT_OPTION_COUNT 2
 
 // Enumeration for optionType in the Speedchoice struct below.
 

--- a/include/global.h
+++ b/include/global.h
@@ -305,6 +305,7 @@ struct SpeedchoiceSaveOptions
     u32 easySurgeCans:2;
     u32 nerfBrock:1;
     u32 startLocation:3;
+    u32 earlyCut:1;
 };
 
 struct DoneButtonStats

--- a/include/global.h
+++ b/include/global.h
@@ -304,6 +304,7 @@ struct SpeedchoiceSaveOptions
     u32 hmBadgeChecks:1;
     u32 easySurgeCans:2;
     u32 nerfBrock:1;
+    u32 startLocation:3;
 };
 
 struct DoneButtonStats

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -85,7 +85,23 @@ static void ClearBattleTower(void)
 
 static void WarpToPlayersRoom(void)
 {
-    SetWarpDestination(MAP_GROUP(PALLET_TOWN_PLAYERS_HOUSE_2F), MAP_NUM(PALLET_TOWN_PLAYERS_HOUSE_2F), -1, 6, 6);
+    switch (gSaveBlock2Ptr->speedchoiceConfig.startLocation) {
+        case START_LOCATION_NORMAL:
+            SetWarpDestination(MAP_GROUP(PALLET_TOWN_PLAYERS_HOUSE_2F), MAP_NUM(PALLET_TOWN_PLAYERS_HOUSE_2F), -1, 6, 6);
+            break;
+        case START_LOCATION_EEVEE:
+            SetWarpDestination(MAP_GROUP(CELADON_CITY_CONDOMINIUMS_ROOF_ROOM), MAP_NUM(CELADON_CITY_CONDOMINIUMS_ROOF_ROOM), -1, 7, 4);
+            break;
+        case START_LOCATION_LAPRAS:
+            SetWarpDestination(MAP_GROUP(SILPH_CO_7F), MAP_NUM(SILPH_CO_7F), -1, 1, 7);
+            break;
+        case START_LOCATION_SAFARI:
+            SetWarpDestination(MAP_GROUP(FUCHSIA_CITY), MAP_NUM(FUCHSIA_CITY), -1, 24, 6);
+            break;
+        case START_LOCATION_TOWER:
+            SetWarpDestination(MAP_GROUP(POKEMON_TOWER_7F), MAP_NUM(POKEMON_TOWER_7F), -1, 11, 5);
+            break;
+    }
     WarpIntoMap();
     sInIntro = FALSE;
     sInSubMenu = FALSE;
@@ -163,6 +179,24 @@ void NewGameInitData(void)
     if (gSaveBlock2Ptr->speedchoiceConfig.raceGoal == GOAL_MANUAL)
         AddBagItem(ITEM_DONE_BUTTON, 1);
     FlagSet(FLAG_SYS_B_DASH);
+
+    if (gSaveBlock2Ptr->speedchoiceConfig.startLocation != START_LOCATION_NORMAL) {
+        // Give the player a weak Magikarp to prevent game crashes.
+        struct Pokemon * mon = AllocZeroed(sizeof(struct Pokemon));
+        if (mon != NULL)
+        {
+            u32 pid;
+            u32 otid = T2_READ_32(gSaveBlock2Ptr->playerTrainerId);
+            do {
+                pid = Random32();
+            } while (!IsShinyOtIdPersonality(otid, pid));
+            CreateMon(mon, SPECIES_MAGIKARP, 1, 0, TRUE, pid, OT_ID_PLAYER_ID, 0);
+            GiveMonToPlayer(mon);
+            Free(mon);
+        }
+        // Show the POKEMON option in the start menu.
+        FlagSet(FLAG_SYS_POKEMON_GET);
+    }
 
 #if DEVMODE
     {

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -194,8 +194,9 @@ void NewGameInitData(void)
             GiveMonToPlayer(mon);
             Free(mon);
         }
-        // Show the POKEMON option in the start menu.
+        // Show the POKEMON and POKEDEX options in the start menu.
         FlagSet(FLAG_SYS_POKEMON_GET);
+        FlagSet(FLAG_SYS_POKEDEX_GET);
     }
 
 #if DEVMODE

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -199,6 +199,12 @@ void NewGameInitData(void)
         FlagSet(FLAG_SYS_POKEDEX_GET);
     }
 
+    if (gSaveBlock2Ptr->speedchoiceConfig.earlyCut == EARLY_CUT_YES) {
+        AddBagItem(ITEM_TM_CASE, 1);
+        AddBagItem(ITEM_HM01, 1);
+        FlagSet(FLAG_GOT_HM01);
+    }
+
 #if DEVMODE
     {
         struct Pokemon * mon = AllocZeroed(sizeof(struct Pokemon));

--- a/src/speedchoice.c
+++ b/src/speedchoice.c
@@ -1473,10 +1473,10 @@ void DrawPageOptions(u8 page) // Page is 1-indexed
     {
         struct SpeedchoiceOption *option = (struct SpeedchoiceOption *)&SpeedchoiceOptions[i + (OPTIONS_PER_PAGE * (page - 1))];
         const u8 *string = option->string;
+        u8 trueIndex = i + ((page - 1) * OPTIONS_PER_PAGE);
 
         AddTextPrinterParameterized3(SPD_WIN_OPTIONS, 2, 4, NEWMENUOPTIONCOORDS(i), sTextColors[SPC_COLOR_GRAY], TEXT_SPEED_FF, string);
         // TODO: Draw on SPD_WIN_OPTIONS, if it's broken
-        u8 trueIndex = i + ((page - 1) * OPTIONS_PER_PAGE);
         DrawGeneralChoices(trueIndex, option, sSpeedchoice->config.optionConfig[trueIndex], i);
     }
 

--- a/src/speedchoice.c
+++ b/src/speedchoice.c
@@ -218,6 +218,9 @@ const u8 gSpeedchoiceOptionEasySurgeCans[] = _("EASY SURGE");
 const u8 gSpeedchoiceOptionNerfBrock[] = _("NERF BROCK");
 const u8 gSpeedchoiceOptionStartLocation[] = _("START IN");
 
+// PAGE 5
+const u8 gSpeedchoiceOptionEarlyCut[] = _("EARLY CUT");
+
 // CONSTANT OPTIONS
 const u8 gSpeedchoiceOptionPage[] = _("PAGE");
 const u8 gSpeedchoiceOptionStartGame[] = _("START GAME");
@@ -254,6 +257,7 @@ const u8 gSpeedchoiceTooltipEasyDexRewards[] = _("Removes Pokédex caught condit
 const u8 gSpeedchoiceTooltipEasySurgeCans[] = _("PURGE: The bottom left can will\nalways contain the first switch,\land the can to the right of it\lwill always contain the second.\pKEEP: Vanilla randomization\nHELL: Anything-goes randomization\lWHY: HELL + no save-scumming");
 const u8 gSpeedchoiceTooltipNerfBrock[] = _("Nerfs LEADER BROCK by\nreducing his party levels by 2.");
 const u8 gSpeedchoiceTooltipStartLocation[] = _("Changes the player's starting location.");
+const u8 gSpeedchoiceTooltipEarlyCut[] = _("Gives HM01 and the ability to use\nit in the field at start.");
 
 // START GAME
 const u8 gSpeedchoiceStartGameText[] = _("CV: {STR_VAR_1}\nStart the game?");
@@ -319,6 +323,7 @@ static const u8 gPresets[NUM_PRESETS][CURRENT_OPTIONS_NUM] = {
         [EASY_SURGE_CANS]  = SURGE_KEEP,
         [NERF_BROCK]       = NERF_NO,
         [START_LOCATION]   = START_LOCATION_NORMAL,
+        [EARLY_CUT]        = EARLY_CUT_NO,
     },
     [PRESET_BINGO]   = {
         [PRESET]           = PRESET_BINGO,
@@ -341,6 +346,7 @@ static const u8 gPresets[NUM_PRESETS][CURRENT_OPTIONS_NUM] = {
         [EASY_SURGE_CANS]  = SURGE_NERF,
         [NERF_BROCK]       = NERF_YES,
         [START_LOCATION]   = START_LOCATION_NORMAL,
+        [EARLY_CUT]        = EARLY_CUT_NO,
     },
     [PRESET_CEA]     = {
         [PRESET]           = PRESET_CEA,
@@ -363,6 +369,7 @@ static const u8 gPresets[NUM_PRESETS][CURRENT_OPTIONS_NUM] = {
         [EASY_SURGE_CANS]  = SURGE_NERF,
         [NERF_BROCK]       = NERF_YES,
         [START_LOCATION]   = START_LOCATION_NORMAL,
+        [EARLY_CUT]        = EARLY_CUT_NO,
     },
     [PRESET_RACE]    = {
         [PRESET]           = PRESET_RACE,
@@ -385,6 +392,7 @@ static const u8 gPresets[NUM_PRESETS][CURRENT_OPTIONS_NUM] = {
         [EASY_SURGE_CANS]  = SURGE_NERF,
         [NERF_BROCK]       = NERF_YES,
         [START_LOCATION]   = START_LOCATION_NORMAL,
+        [EARLY_CUT]        = EARLY_CUT_NO,
     },
 };
 
@@ -690,6 +698,17 @@ const struct SpeedchoiceOption SpeedchoiceOptions[CURRENT_OPTIONS_NUM + 1] = // 
         .tooltip = gSpeedchoiceTooltipStartLocation,
     },
     // ----------------------------------
+    // EARLY CUT OPTION
+    // ----------------------------------
+    [EARLY_CUT] = {
+      .optionCount = EARLY_CUT_OPTION_COUNT,
+        .optionType = NORMAL,
+        .enabled = TRUE,
+        .string = gSpeedchoiceOptionEarlyCut,
+        .options = OptionChoiceConfigYesNo,
+        .tooltip = gSpeedchoiceTooltipEarlyCut,
+    },
+    // ----------------------------------
     // PAGE STATIC OPTION
     // ----------------------------------
     [PAGE] = {
@@ -762,6 +781,7 @@ void SetByteArrayToSaveOptions(const u8 * options_arr)
     gSaveBlock2Ptr->speedchoiceConfig.nerfBrock = options_arr[NERF_BROCK];
     gSaveBlock2Ptr->speedchoiceConfig.nerfBrock = options_arr[NERF_BROCK];
     gSaveBlock2Ptr->speedchoiceConfig.startLocation = options_arr[START_LOCATION];
+    gSaveBlock2Ptr->speedchoiceConfig.earlyCut = options_arr[EARLY_CUT];
 }
 
 /*
@@ -821,6 +841,8 @@ u8 CheckSpeedchoiceOption(u8 option)
         return gSaveBlock2Ptr->speedchoiceConfig.easySurgeCans;
     case NERF_BROCK:
         return gSaveBlock2Ptr->speedchoiceConfig.nerfBrock;
+    case EARLY_CUT:
+        return gSaveBlock2Ptr->speedchoiceConfig.earlyCut;
     default:
         return 0xFF;
     }


### PR DESCRIPTION
This adds an alternate start location with the same starting options as
the Pokemon Red Speedchoice mod.

I didn't test this thoroughly to make sure that alternate starting
locations don't cause game-breaking issues, but I did make sure each
starting location worked and that basic gameplay features (battles,
menus, etc) worked.